### PR TITLE
Initial implementation of subspaces

### DIFF
--- a/test/clj_foundationdb/core_test.clj
+++ b/test/clj_foundationdb/core_test.clj
@@ -134,9 +134,9 @@
 
 (deftest test-get-first-greater-than
   (testing "Test first greater than"
-    (let [fd (. FDB selectAPIVersion 510)
-          key "bar"
-          value "1"
+    (let [fd            (. FDB selectAPIVersion 510)
+          key           "bar"
+          value         "1"
           expected-keys '("bar1")]
       (with-open [db (.open fd)]
         (tr! db
@@ -167,9 +167,9 @@
 
 (deftest test-get-first-greater-or-equal
   (testing "Test first greater or equal"
-    (let [fd (. FDB selectAPIVersion 510)
-          key "bar"
-          value "1"
+    (let [fd            (. FDB selectAPIVersion 510)
+          key           "bar"
+          value         "1"
           expected-keys '("bar")]
       (with-open [db (.open fd)]
         (tr! db
@@ -242,3 +242,31 @@
              (set-val tr key value)
              (clear-all tr)
              (is (empty? (get-all tr))))))))
+
+(deftest test-subspace
+  (testing "Test simple subspace"
+    (let [fd    (. FDB selectAPIVersion 510)
+          key   "foo"
+          value "bar"]
+      (with-open [db (.open fd)]
+        (tr! db
+             (clear-all tr)
+             (with-subspace "class"
+               (set-val tr key value)
+               (is (= (get-val tr key) value)))
+             (is (nil? (get-val tr key)))
+             (is (= (get-all tr) [[["class" "foo"] "bar"]]))))))
+
+  (testing "Test multiple level subspace"
+    (let [fd    (. FDB selectAPIVersion 510)
+          key   "foo"
+          value "bar"]
+      (with-open [db (.open fd)]
+        (tr! db
+             (clear-all tr)
+             (with-subspace ["class" "intro"]
+               (set-val tr key value)
+               (is (= (get-val tr key) value)))
+             (is (nil? (get-val tr key)))
+             (is (= (get-range tr ["class"]) [[["class" "intro" "foo"] "bar"]]))
+             (is (= (get-all tr) [[["class" "intro" "foo"] "bar"]])))))))


### PR DESCRIPTION
* Initial implementation of subspaces for set-val and get-val.
* This binds the subspace key to *subspace* and then uses them in the context. This also introduces a `with-subspace` macro where the given commands are executed with the subspace prefixed to the keys inside the block.

The approach was taken from Carmine where this server-connection is bound in a similar way

Relevant code : 

https://github.com/ptaoussanis/carmine/blob/master/src/taoensso/carmine/protocol.clj#L19-L23

https://github.com/ptaoussanis/carmine/blob/master/src/taoensso/carmine.clj#L58-L62